### PR TITLE
Add release notes conference

### DIFF
--- a/list.json
+++ b/list.json
@@ -24,5 +24,13 @@
     "month": "May",
     "submissionDeadline": "",
     "country": "USA"
-  }
+  },
+  {
+    "title": "Release Notes (iOS & Mac)",
+    "url": "https://releasenotes.tv/conference/",
+    "where": "Midwestern US (locations vary)",
+    "when": "Fall 2018",
+    "submissionDeadline": "",
+    "country": "USA"
+  },
 ]


### PR DESCRIPTION
It's not bootstrapper-specific, but focuses more on the business of ios/mac software and contains a sizeable number of bootstrappers.